### PR TITLE
pc - Add github workflows for frontend, and the template for the github pages site

### DIFF
--- a/.github/workflows/01-gh-pages-pr-table.yml
+++ b/.github/workflows/01-gh-pages-pr-table.yml
@@ -1,0 +1,82 @@
+# This workflow updates the open PRs in
+# _config.yml each time a pull request is made
+# or there is a push to main.  It does not handle
+# the rebuild of the storybook or javadoc; that's handled
+# separately based on which files were modified.
+
+name: "01-gh-pages-pr-table: Rebuild table of PRs"
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+          
+env:
+  GH_TOKEN: ${{ github.token }}
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+  pull-requests: read
+
+jobs: 
+  get-pull-requests:
+    name: Get Pull Requests
+    runs-on: ubuntu-latest
+    outputs:
+      pull_requests: ${{ steps.get-prs.outputs.pull_requests }}
+    steps:
+    - name: Checkout local code to establish repo
+      uses: actions/checkout@v4
+    - name: Get Pull Requests from Github api
+      id: get-prs
+      run: |
+         gh pr list -s open --json url,author,number,title,headRefName 
+         gh pr list -s open --json url,author,number,title,headRefName > prs.json
+         cat prs.json
+         pull_requests=`cat prs.json`
+         echo "pull_requests=${pull_requests}"
+         echo "pull_requests=${pull_requests}" >> "$GITHUB_OUTPUT"
+  build-basic-site:
+    name: Build Basic Site
+    runs-on: ubuntu-latest
+    needs: [get-pull-requests]
+
+    steps:
+    - name: Checkout local code to establish repo
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+
+    - name: Append name of site to _config.yml
+      run: | 
+          CONFIG_YML=frontend/docs-index/_config.yml
+          OWNER_PLUS_REPOSITORY=${{github.repository}}
+          OWNER=${{ github.repository_owner }}
+          REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
+          echo "repo: ${OWNER_PLUS_REPOSITORY}" >> ${CONFIG_YML}
+          echo "owner: ${OWNER}" >> ${CONFIG_YML}
+          echo "repo_name: ${REPOSITORY}" >> ${CONFIG_YML}    
+          cat ${CONFIG_YML}
+    - name: Store PRs as JSON in _config.yml
+      run: |
+         pull_requests=${{toJSON(needs.get-pull-requests.outputs.pull_requests)}}
+         CONFIG_YML=frontend/docs-index/_config.yml
+         echo "pull_requests: ${pull_requests}, CONFIG_YML: ${CONFIG_YML}"
+         echo "pull_requests: ${pull_requests}" >> ${CONFIG_YML}
+         cat ${CONFIG_YML}
+    - name: Compose web site
+      run: |
+        mkdir -p site
+        cp -r frontend/docs-index/* site
+  
+    - name: Deploy 🚀
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        folder: site # The folder the action should deploy.
+        branch: gh-pages
+        clean: false # Automatically remove deleted files from the deploy branch

--- a/.github/workflows/30-frontend-tests.yml
+++ b/.github/workflows/30-frontend-tests.yml
@@ -1,0 +1,34 @@
+name: "30-frontend-tests: JavaScript, Jest Unit tests"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths: [frontend/**, .github/workflows/30-frontend-tests.yml]
+  push:
+    branches: [main]
+    paths: [frontend/**, .github/workflows/30-frontend-tests.yml]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: szenius/set-timezone@v1.2
+        with:
+          timezoneLinux: "America/Los_Angeles"
+      - uses: actions/checkout@v4
+        with: 
+          fetch-depth: 2
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'frontend/package.json'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: npm ci
+        working-directory: ./frontend
+      - run: npm test
+        working-directory: ./frontend
+    

--- a/.github/workflows/32-frontend-coverage.yml
+++ b/.github/workflows/32-frontend-coverage.yml
@@ -1,0 +1,75 @@
+name: "32-frontend-coverage: Frontend Coverage (JavaScript/Jest)"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths: [frontend/**, .github/workflows/32-frontend-coverage.yml]
+  push:
+    branches: [main]
+    paths: [frontend/**, .github/workflows/32-frontend-coverage.yml]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: szenius/set-timezone@v1.2
+        with:
+          timezoneLinux: "America/Los_Angeles"
+      - uses: actions/checkout@v4
+        with: 
+          fetch-depth: 2
+
+      - name: Get PR number
+        id: get-pr-num
+        run: |
+          echo "GITHUB_EVENT_PATH=${GITHUB_EVENT_PATH}"
+          pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          echo "pr_number=${pr_number}" 
+          if [[ "${pr_number}" == "null" ]]; then
+            echo "This is not a PR"
+            pr_number="main"
+          fi
+          echo "pr_number=${pr_number}" >> "$GITHUB_ENV"
+                
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'frontend/package.json'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: npm ci
+        working-directory: ./frontend
+      - run: npm run coverage
+        working-directory: ./frontend
+      - name: Upload jest coverage report to Artifacts
+        if: always() # always upload artifacts, even if tests fail
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: jest-coverage
+          path: frontend/coverage/lcov-report/*
+     
+      - name: Set path for github pages deploy when there is a PR num
+        if: always() # always upload artifacts, even if tests fail
+        run: |
+          if [ "${{env.pr_number }}" = "main" ]; then
+              prefix=""
+          else
+              prefix="prs/${{ env.pr_number }}/"
+          fi
+          echo "prefix=${prefix}"
+          echo "prefix=${prefix}" >> "$GITHUB_ENV"
+      
+      - name: Deploy 🚀
+        if: always() # always upload artifacts, even if tests fail
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: frontend/coverage/lcov-report # The folder where the javadoc files are located
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: ${{env.prefix}}coverage # The folder that we serve our javadoc files from
+
+
+  

--- a/.github/workflows/33-frontend-pr-mutation-testing.yml
+++ b/.github/workflows/33-frontend-pr-mutation-testing.yml
@@ -41,9 +41,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: './frontend/package.json'
-          cache: 'npm'
-          cache-dependency-path: './frontend/package-lock.json
+            node-version-file: './frontend/package.json'
+            cache: 'npm'
+            cache-dependency-path: frontend/package-lock.json
 
       - name: Create directory in case it doesn't exist
         run: |

--- a/.github/workflows/33-frontend-pr-mutation-testing.yml
+++ b/.github/workflows/33-frontend-pr-mutation-testing.yml
@@ -1,0 +1,91 @@
+name: "33-frontend-pr-mutation-testing: Stryker JS Mutation Testing (JavaScript/Jest)"
+
+# This workflow pulls incremental mutation testing results
+# if they exist for the given PR, and then 
+# uses those incremental results to run mutation testing faster.
+# Reference: https://stryker-mutator.io/docs/stryker-js/incremental/
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths: [frontend/**, .github/workflows/33-frontend-pr-mutation-testing.yml]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    env:
+      destination: frontend/reports/mutation
+
+    steps:
+      
+      - uses: szenius/set-timezone@v1.2
+        with:
+          timezoneLinux: "America/Los_Angeles"
+      - uses: actions/checkout@v4
+        with: 
+          fetch-depth: 0
+
+      - name: Get PR number
+        id: get-pr-num
+        run: |
+          echo "GITHUB_EVENT_PATH=${GITHUB_EVENT_PATH}"
+          pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          echo "pr_number=${pr_number}" 
+          if [[ "${pr_number}" == "null" ]]; then
+            echo "This is not a PR"
+            pr_number="main"
+          fi
+          echo "pr_number=${pr_number}" >> "$GITHUB_ENV"
+          
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: './frontend/package.json'
+          cache: 'npm'
+          cache-dependency-path: './frontend/package-lock.json
+
+      - name: Create directory in case it doesn't exist
+        run: |
+          mkdir -p frontend/reports/mutation
+    
+      - run: npm ci
+        working-directory: ./frontend
+
+      # Modified from https://stackoverflow.com/a/74268200
+
+      - name: Run stryker on changed files
+        id: changed-files
+        run: | 
+            git diff --name-only -r origin/main HEAD |              # get changed files in PR
+            grep "\.js" |                                           # remove non .js files from list
+            sed 's|\(.*\)tests\(.*\)\.test.js|\1main\2.js|' |       # alters test files to main files to account for changed tests
+            grep -v "\.stories\.js" |                               # remove .stories.js files from list
+            grep "src/main/" |                                      # remove files outside of src/main
+            sed 's|frontend/||' |                                   # remove 'frontend/' from file paths
+            sort -u |                                               # remove duplicates
+            xargs -I{} sh -c '[ -f "{}" ] && echo "{}"' |           # check if file exists
+            xargs printf '%s,' |                                    # convert to comma separated list
+            sed 's/.$//' |                                          # remove trailing comma
+            xargs -r npx stryker run --mutate                       # run stryker on changed files
+        working-directory: ./frontend
+
+      - name: Set path for github pages deploy when there is a PR num
+        if: always() # always upload artifacts, even if tests fail
+        run: |
+          if [ "${{env.pr_number }}" = "main" ]; then
+             prefix=""
+          else
+             prefix="prs/${{ env.pr_number }}/"
+          fi
+          echo "prefix=${prefix}"
+          echo "prefix=${prefix}" >> "$GITHUB_ENV"
+      
+      - name: Deploy 🚀
+        if: always() # always upload artifacts, even if tests fail
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: frontend/reports/mutation # The folder where the javadoc files are located
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: ${{env.prefix}}/stryker # The folder that we serve our javadoc files from

--- a/.github/workflows/34-frontend-main-mutation-testing.yml
+++ b/.github/workflows/34-frontend-main-mutation-testing.yml
@@ -1,0 +1,66 @@
+# Running this script will run a full mutation coverage report
+# (not incremental) on the main branch.
+
+name: "34-frontend-main-testing: Stryker JS Mutation Testing (JavaScript/Jest)"
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths: [frontend/**, .github/workflows/34-frontend-main-testing-stryker-js-mutation-testing.yml]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 80
+
+    steps:
+      - uses: szenius/set-timezone@v1.2
+        with:
+          timezoneLinux: "America/Los_Angeles"
+      - uses: actions/checkout@v4
+        with: 
+          fetch-depth: 2
+
+      - name: Create directory in case it doesn't exist
+        run: |
+          mkdir -p frontend/reports
+
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v2.27.0
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          branch: main
+          name: stryker-incremental-main.json
+          path: frontend/reports
+          check_artifacts: true
+          if_no_artifact_found: warn
+
+      - run: npm ci
+        working-directory: ./frontend
+
+      - run: npx stryker run --incremental --incrementalFile reports/stryker-incremental-main.json
+        working-directory: ./frontend
+
+      - name: Upload stryker incremental file to Artifacts
+        if: always() # always upload artifacts, even if tests fail
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: stryker-incremental-main.json
+          path: frontend/reports/stryker-incremental-main.json
+
+      - name: Upload stryker report to Artifacts
+        if: always() # always upload artifacts, even if tests fail
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: stryker-report
+          path: frontend/reports/mutation/*
+  
+      - name: Deploy 🚀
+        if: always() # always upload artifacts, even if tests fail
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: frontend/reports/mutation # The folder where the javadoc files are located
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: stryker # The folder that we serve our javadoc files from

--- a/.github/workflows/35-frontend-format.yml
+++ b/.github/workflows/35-frontend-format.yml
@@ -1,0 +1,29 @@
+name: "35-frontend-format: JavaScript format checking"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths: [frontend/**, .github/workflows/36-frontend-eslint.yml]
+  push:
+    branches: [main]
+    paths: [frontend/**, .github/workflows/36-frontend-eslint.yml]
+
+jobs:
+  check-format:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'frontend/package.json'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+        working-directory: ./frontend
+      - run: npm run check-format
+        working-directory: ./frontend

--- a/.github/workflows/36-frontend-eslint.yml
+++ b/.github/workflows/36-frontend-eslint.yml
@@ -1,0 +1,32 @@
+name: "36-frontend-eslint: JavaScript style checking"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths: [frontend/**, .github/workflows/36-frontend-eslint.yml]
+  push:
+    branches: [main]
+    paths: [frontend/**, .github/workflows/36-frontend-eslint.yml]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: szenius/set-timezone@v1.2
+        with:
+          timezoneLinux: "America/Los_Angeles"
+      - uses: actions/checkout@v4
+        with: 
+          fetch-depth: 2
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'frontend/package.json'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+        working-directory: ./frontend
+      - run: npx eslint --max-warnings 0 .
+        working-directory: ./frontend

--- a/.github/workflows/52-storybook-main-branch.yml
+++ b/.github/workflows/52-storybook-main-branch.yml
@@ -1,0 +1,51 @@
+# Creates/Resets the gh-pages branch to the intended start state
+
+name: "52-storybook-main-branch: Update storybook when main branch changes"
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - frontend/**
+      - .github/workflows/52-storybook-main-branch.yml
+
+env:
+  GH_TOKEN: ${{ github.token }}
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs: 
+  build-storybook-main:
+    name: Storybook (main branch)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-node@v4
+      with:
+          node-version-file: './frontend/package.json'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+    - name: Install dependencies
+      working-directory: ./frontend
+      # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
+      run: npm ci
+    - name: Build Storybook for main branch
+      working-directory: frontend
+      run: | # Install npm packages and build the Storybook files
+        npm run build-storybook -- --docs -o storybook_static
+
+    - name: Deploy 🚀
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        branch: gh-pages # The branch the action should deploy to.
+        folder: frontend/storybook_static # The folder that the build-storybook script generates files.
+        clean: true # Automatically remove deleted files from the deploy branch
+        target-folder: storybook # The folder that we serve our Storybook files from
+   

--- a/.github/workflows/53-chromatic-main-branch.yml
+++ b/.github/workflows/53-chromatic-main-branch.yml
@@ -1,0 +1,67 @@
+# Creates/Resets the gh-pages branch to the intended start state
+
+name: "53-chromatic-main-branch: Update chromatic when main branch changes"
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - frontend/**
+      - .github/workflows/53-chromatic-main-branch.yml
+
+env:
+  GH_TOKEN: ${{ github.token }}
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs: 
+  build-chromatic-main:
+    name: Chromatic(main branch)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: './frontend/package.json'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
+        working-directory: ./frontend
+        # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
+        run: npm ci
+      - name: Run Chromatic
+        id: run_chromatic
+        uses: chromaui/action@latest
+        with:
+          # ⚠️ Make sure to configure a `CHROMATIC_PROJECT_TOKEN` repository secret
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: frontend
+      - name: Echo output
+        run: |
+          echo "Chromatic URL: ${{ steps.run_chromatic.outputs.url }}"
+          echo "Chromatic build ID: ${{ steps.run_chromatic.outputs.storybookUrl }}"
+
+      - name: Build redirect file
+        working-directory: frontend
+        run: | # Create a redirect file to redirect to the storybook online
+          mkdir -p chromatic_static
+          echo "<meta http-equiv=refresh content=0;url=${{steps.run_chromatic.outputs.storybookUrl}}>" > chromatic_static/index.html
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+            branch: gh-pages # The branch the action should deploy to.
+            folder: frontend/chromatic_static # source
+            clean: true # Automatically remove deleted files from the deploy branch
+            target-folder: chromatic # destination 
+       
+     
+   

--- a/.github/workflows/54-storybook-pr.yml
+++ b/.github/workflows/54-storybook-pr.yml
@@ -1,0 +1,92 @@
+# Creates/Resets the gh-pages branch to the intended start state
+
+name: "54-storybook-pr: Update storybook for a pr to main"
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - frontend/**
+      - .github/workflows/54-storybook-pr.yml
+
+env:
+  GH_TOKEN: ${{ github.token }}
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs: 
+  get-pr-num:
+    name: Get PR Number
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.get-pr-num.outputs.pr_number }}
+      branch_name: ${{ steps.get-branch-name.outputs.branch_name }}
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+        token: ${{ github.token }}
+    - name: Get PR number
+      id: get-pr-num
+      run: |
+         echo "GITHUB_EVENT_PATH=${GITHUB_EVENT_PATH}"
+         pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+         echo "pr_number=${pr_number}" 
+         echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
+    - name: Figure out Branch name
+      id: get-branch-name
+      run: | 
+          GITHUB_HEAD_REF="${GITHUB_HEAD_REF}"
+          echo GITHUB_HEAD_REF=${GITHUB_HEAD_REF}
+          GITHUB_REF_CLEANED=${GITHUB_REF/refs\/heads\//}
+          echo GITHUB_REF_CLEANED=${GITHUB_REF_CLEANED}
+          GITHUB_REF_CLEANED=${GITHUB_REF_CLEANED//\//-}
+          echo GITHUB_REF_CLEANED=${GITHUB_REF_CLEANED}
+          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_CLEANED}}"
+          echo "branch_name=${BRANCH}"
+          echo "branch_name=${BRANCH}" >> "$GITHUB_OUTPUT"
+
+  build-storybook-for-this-pr:
+    name: Build Storybook for PR
+    runs-on: ubuntu-latest
+    needs: [get-pr-num]        
+    steps:
+    - name: Debugging output
+      run: |
+        echo "pr_number=${{needs.get-pr-num.outputs.pr_number}}"
+        echo "branch_name=${{needs.get-pr-num.outputs.branch_name}}"
+
+    - name: Checkout repo
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ needs.get-pr-num.outputs.branch_name }}
+        fetch-depth: 1
+        token: ${{ github.token }}
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: './frontend/package.json'
+        cache: 'npm'
+        cache-dependency-path: frontend/package-lock.json
+
+    - name: Build Storybook for PR branch
+      working-directory: frontend
+      run: | # Install npm packages and build the Storybook files
+        npm install
+        npm run build-storybook -- --docs -o storybook_static_${{ needs.get-pr-num.outputs.pr_number }}
+    - name: Deploy 🚀
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        branch: gh-pages # The branch the action should deploy to.
+        folder: frontend/storybook_static_${{ needs.get-pr-num.outputs.pr_number }} # The folder that the build-storybook script generates files.
+        clean: true # Automatically remove deleted files from the deploy branch
+        target-folder: prs/${{ needs.get-pr-num.outputs.pr_number }}/storybook # The folder that we serve our Storybook files from 
+  
+  
+ 

--- a/.github/workflows/55-chromatic-pr.yml
+++ b/.github/workflows/55-chromatic-pr.yml
@@ -1,0 +1,107 @@
+# Creates/Resets the gh-pages branch to the intended start state
+
+name: "55-chromatic-pr: Update chromatic for a pr to main"
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - frontend/**
+      - .github/workflows/55-chromatic-pr.yml
+
+env:
+  GH_TOKEN: ${{ github.token }}
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs: 
+  get-pr-num:
+    name: Get PR Number
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.get-pr-num.outputs.pr_number }}
+      branch_name: ${{ steps.get-branch-name.outputs.branch_name }}
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+        token: ${{ github.token }}
+    - name: Get PR number
+      id: get-pr-num
+      run: |
+         echo "GITHUB_EVENT_PATH=${GITHUB_EVENT_PATH}"
+         pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+         echo "pr_number=${pr_number}" 
+         echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
+    - name: Figure out Branch name
+      id: get-branch-name
+      run: | 
+          GITHUB_HEAD_REF="${GITHUB_HEAD_REF}"
+          echo GITHUB_HEAD_REF=${GITHUB_HEAD_REF}
+          GITHUB_REF_CLEANED=${GITHUB_REF/refs\/heads\//}
+          echo GITHUB_REF_CLEANED=${GITHUB_REF_CLEANED}
+          GITHUB_REF_CLEANED=${GITHUB_REF_CLEANED//\//-}
+          echo GITHUB_REF_CLEANED=${GITHUB_REF_CLEANED}
+          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_CLEANED}}"
+          echo "branch_name=${BRANCH}"
+          echo "branch_name=${BRANCH}" >> "$GITHUB_OUTPUT"
+
+  build-chromatic-for-this-pr:
+    name: Build Chromatic for PR
+    runs-on: ubuntu-latest
+    needs: [get-pr-num]        
+    steps:
+    - name: Debugging output
+      run: |
+        echo "pr_number=${{needs.get-pr-num.outputs.pr_number}}"
+        echo "branch_name=${{needs.get-pr-num.outputs.branch_name}}"
+
+    - name: Checkout repo
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ needs.get-pr-num.outputs.branch_name }}
+        fetch-depth: 0
+        token: ${{ github.token }}
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+          node-version-file: './frontend/package.json'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+  
+    - name: Install dependencies
+      working-directory: ./frontend
+      run: npm ci
+    - name: Run Chromatic
+      id: run_chromatic
+      uses: chromaui/action@latest
+      with:
+          # ⚠️ Make sure to configure a `CHROMATIC_PROJECT_TOKEN` repository secret
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: frontend
+    - name: Echo output
+      run: |
+          echo "Chromatic URL: ${{ steps.run_chromatic.outputs.url }}"
+          echo "Chromatic build ID: ${{ steps.run_chromatic.outputs.storybookUrl }}"
+    - name: Build redirect file
+      working-directory: frontend
+      run: | # Create a redirect file to redirect to the storybook online
+          mkdir -p chromatic_static_${{ needs.get-pr-num.outputs.pr_number }}
+          echo "<meta http-equiv=refresh content=0;url=${{steps.run_chromatic.outputs.storybookUrl}}>" > chromatic_static_${{ needs.get-pr-num.outputs.pr_number }}/index.html
+          echo "<meta http-equiv=refresh content=0;url=${{steps.run_chromatic.outputs.url}}>" > chromatic_static_${{ needs.get-pr-num.outputs.pr_number }}/build.html
+    - name: Deploy 🚀
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        branch: gh-pages # The branch the action should deploy to.
+        folder: frontend/chromatic_static_${{ needs.get-pr-num.outputs.pr_number }} # The folder that the build-chromatic script generates files.
+        clean: true # Automatically remove deleted files from the deploy branch
+        target-folder: prs/${{ needs.get-pr-num.outputs.pr_number }}/chromatic # The folder that we serve our chromatic files from 
+  
+  
+ 

--- a/frontend/docs-index/_config.yml
+++ b/frontend/docs-index/_config.yml
@@ -1,0 +1,22 @@
+
+title: Documentation
+description: >- # this means to ignore newlines until "baseurl:"
+  When reviewing a PR for this repo, you can see what the documentation,
+  e.g. the storybook, will look like when published for the branches
+  named above.
+baseurl: "" # the subpath of your site, e.g. /blog
+url: "" # the base hostname & protocol for your site, e.g. http://example.com
+
+# Build settings
+theme: minima
+plugins:
+  - jekyll-feed
+
+collections:
+  branches:
+    output: true
+    permalink: /branches/:path/
+
+repo_name: "TBD"
+
+

--- a/frontend/docs-index/_layouts/default.html
+++ b/frontend/docs-index/_layouts/default.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>{{ site.repo_name }}</title>
+  </head>
+  <body>
+    <h1>Documentation for {{site.repo_name}}</h1>
+    <section>
+      {{ content }}
+    </section>
+    <footer>
+    </footer>
+  </body>
+</html>

--- a/frontend/docs-index/index.md
+++ b/frontend/docs-index/index.md
@@ -1,0 +1,144 @@
+
+<!-- markdownlint-disable MD033 MD041 -->
+<!-- disabling MD033 allows inline html -->
+<!-- disabling MD041 allows starting with something other than an H1 -->
+
+<style>
+table, th, td {
+  border: 1px solid black;
+  padding: 2px;
+  border-collapse: collapse;
+}
+tbody tr:nth-child(even) {background-color: #f2f2f2;}
+</style>
+
+* Source Repo: <https://github.com/{{site.repo}}>
+* Github Actions: <https://github.com/{{site.repo}}/actions>
+
+## Documentation
+
+<table>
+<thead>
+<tr>
+<th colspan="1" style="text-align:center">Backend</th>
+<th colspan="3" style="text-align:center">Frontend (Storybook/Chromatic)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="javadoc">javadoc</a></td>
+<td><a href="storybook">local sb</a></td>
+<td><a href="chromatic">chromatic sb</a></td>
+<td><a href="chromatic/build.html">build info</a></td>
+</tr>
+</tbody>
+</table>
+
+## Test Coverage
+
+<table>
+<thead>
+<tr>
+<th colspan="2" style="text-align:center">Backend</th>
+<th colspan="2" style="text-align:center">Frontend</th>
+</tr>
+<tr>
+<th>Jacoco</th>
+<th>Pitest</th>
+<th>Coverage</th>
+<th>Stryker</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="jacoco">jacoco</a></td>
+<td><a href="pitest">pitest</a></td>
+<td><a href="coverage">coverage</a></td>
+<td><a href="stryker/mutation.html">stryker</a></td>
+</tr>
+</tbody>
+</table>
+
+## Open Pull Requests
+
+### Documentation for PRs
+
+<table>
+<thead>
+<tr>
+<th colspan="3" style="text-align:center">Pull Request</th>
+<th colspan="1" style="text-align:center">Backend</th>
+<th colspan="3" style="text-align:center">Frontend (Storybook/Chromatic)</th>
+</tr>
+<tr>
+<th>PR</th>
+<th>Branch</th>
+<th>Author</th>
+<th>Javadoc</th>
+<th>local sb</th>
+<th>chromatic sb</th>
+<th>build info</th>
+</tr>
+</thead>
+<tbody>
+{% for pr in site.pull_requests %}
+<tr>
+<td><a href="{{pr.url}}">PR {{pr.number}}</a></td>
+<td>{{pr.headRefName}}</td>
+<td>{{pr.author.login}}</td>
+<td><a href="prs/{{pr.number}}/javadoc">javadoc</a></td>
+<td><a href="prs/{{pr.number}}/storybook">local sb</a></td>
+<td><a href="prs/{{pr.number}}/chromatic">chromatic sb</a></td>
+<td><a href="prs/{{pr.number}}/chromatic/build.html">build info</a></td>
+</tr>
+{% endfor %}
+</tbody>
+</table>
+
+### Test Coverage for PRs
+
+<table>
+<thead>
+<tr>
+<th colspan="3" style="text-align:center">Pull Request</th>
+<th colspan="2" style="text-align:center">Backend</th>
+<th colspan="2" style="text-align:center">Frontend</th>
+</tr>
+<tr>
+<th>PR</th>
+<th>Branch</th>
+<th>Author</th>
+<th>Jacoco</th>
+<th>Pitest</th>
+<th>Coverage</th>
+<th>Stryker</th>
+</tr>
+</thead>
+<tbody>
+{% for pr in site.pull_requests %}
+<tr>
+<td><a href="{{pr.url}}">PR {{pr.number}}</a></td>
+<td>{{pr.headRefName}}</td>
+<td>{{pr.author.login}}</td>
+<td><a href="prs/{{pr.number}}/jacoco">jacoco</a></td>
+<td><a href="prs/{{pr.number}}/pitest">pitest</a></td>
+<td><a href="prs/{{pr.number}}/coverage">coverage</a></td>
+<td><a href="prs/{{pr.number}}/stryker/mutation.html">stryker</a></td>
+</tr>
+{% endfor %}
+</tbody>
+</table>
+
+## Notes
+
+If links in the PR tables don't work, note the following:
+
+* Backend links may not be updated for PRs that do not touch the backend code.
+* Frontend links may not be updated for PRs that do not touch the frontend code.
+* If a link doesn't work when you expect that it should, check that the appropriate [Github Actions](https://github.com/{{site.repo}}/actions) workflow completed successfully.
+* You can also check the contents of the [gh-pages branch of this repo](https://github.com/{{site.repo}}/tree/gh-pages) to see if they were updated with the appropriate directory.
+* Note that the pitest runs that are triggered by PRs and by workflow 2 compute
+  incremental pitest results based on stored history.  It is rare, but this may
+  occasionally be different from the results when doing a full pitest run from
+  scratch, which is done every time a push is made to the main branch (for example,
+  when merging a PR).

--- a/frontend/docs-index/storybook_placeholder.html
+++ b/frontend/docs-index/storybook_placeholder.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Storybook Placeholder</title>
+    </head>
+    <body>
+        <h1>Storybook Placeholder</h1>
+        <p>
+            This page will be replaced with the Storybook for the main branch
+            when the Github Actions workflow to build it completes successfully.
+        </p>
+    </body>
+</html>

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -28,6 +28,7 @@ export default [
       "react/react-in-jsx-scope": "off",
       "react/jsx-uses-react": "off",
       "react/prop-types": "off",
+      "react/no-unescaped-entities": "off"
     },
   },
 ];

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -47,6 +47,9 @@
         "storybook": "^8.2.9",
         "typescript-eslint": "^8.2.0",
         "webpack": "^5.93.0"
+      },
+      "engines": {
+        "node": "=v20.17.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,9 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "=v20.17.0"
+  },
   "dependencies": {
     "@jest/core": "^29.7.0",
     "@testing-library/jest-dom": "^5.17.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "coverage": "nyc --reporter=html --reporter=text-summary react-scripts test --watchAll --coverage",
+    "coverage": "react-scripts test --watchAll=false --coverage; echo \"Coverage report is available at file://`pwd`/coverage/lcov-report/index.html\"",
     "check-format": "prettier --check \"src/**/*.{js,jsx}\"",
     "format": "prettier --write \"src/**/*.{js,jsx}\"",
     "storybook": "storybook dev -p 6006",

--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -2,13 +2,13 @@ import { Container } from "react-bootstrap";
 
 export default function Footer() {
   return (
-    <footer className="bg-light pt-3 pt-md-4 pb-4 pb-md-5">
+    <footer className="bg-light pt-3 pt-md-4 pb-4 pb-md-5" data-testid="Footer">
       <Container>
         <p>
           This is a sample webapp using React with a Spring Boot backend. See
           the source code on{" "}
           <a href="https://github.com/ucsb-cs156/spring-react-template">
-            Github
+            Github.
           </a>
         </p>
       </Container>

--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -4,7 +4,13 @@ export default function Footer() {
   return (
     <footer className="bg-light pt-3 pt-md-4 pb-4 pb-md-5">
       <Container>
-        <p>This is a sample webapp using React with a Spring Boot backend.</p>
+        <p>
+          This is a sample webapp using React with a Spring Boot backend. See
+          the source code on{" "}
+          <a href="https://github.com/ucsb-cs156/spring-react-template">
+            Github
+          </a>
+        </p>
       </Container>
     </footer>
   );

--- a/frontend/src/stories/Button.jsx
+++ b/frontend/src/stories/Button.jsx
@@ -1,16 +1,20 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import './button.css';
+import React from "react";
+import PropTypes from "prop-types";
+import "./button.css";
 
 /**
  * Primary UI component for user interaction
  */
 export const Button = ({ primary, backgroundColor, size, label, ...props }) => {
-  const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
+  const mode = primary
+    ? "storybook-button--primary"
+    : "storybook-button--secondary";
   return (
     <button
       type="button"
-      className={['storybook-button', `storybook-button--${size}`, mode].join(' ')}
+      className={["storybook-button", `storybook-button--${size}`, mode].join(
+        " ",
+      )}
       style={backgroundColor && { backgroundColor }}
       {...props}
     >
@@ -31,7 +35,7 @@ Button.propTypes = {
   /**
    * How large should the button be?
    */
-  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  size: PropTypes.oneOf(["small", "medium", "large"]),
   /**
    * Button contents
    */
@@ -45,6 +49,6 @@ Button.propTypes = {
 Button.defaultProps = {
   backgroundColor: null,
   primary: false,
-  size: 'medium',
+  size: "medium",
   onClick: undefined,
 };

--- a/frontend/src/stories/Button.stories.js
+++ b/frontend/src/stories/Button.stories.js
@@ -1,19 +1,19 @@
-import { fn } from '@storybook/test';
-import { Button } from './Button';
+import { fn } from "@storybook/test";
+import { Button } from "./Button";
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 export default {
-  title: 'Example/Button',
+  title: "Example/Button",
   component: Button,
   parameters: {
     // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
-    layout: 'centered',
+    layout: "centered",
   },
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
-  tags: ['autodocs'],
+  tags: ["autodocs"],
   // More on argTypes: https://storybook.js.org/docs/api/argtypes
   argTypes: {
-    backgroundColor: { control: 'color' },
+    backgroundColor: { control: "color" },
   },
   // Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#action-args
   args: { onClick: fn() },
@@ -23,26 +23,26 @@ export default {
 export const Primary = {
   args: {
     primary: true,
-    label: 'Button',
+    label: "Button",
   },
 };
 
 export const Secondary = {
   args: {
-    label: 'Button',
+    label: "Button",
   },
 };
 
 export const Large = {
   args: {
-    size: 'large',
-    label: 'Button',
+    size: "large",
+    label: "Button",
   },
 };
 
 export const Small = {
   args: {
-    size: 'small',
-    label: 'Button',
+    size: "small",
+    label: "Button",
   },
 };

--- a/frontend/src/stories/Header.jsx
+++ b/frontend/src/stories/Header.jsx
@@ -1,14 +1,19 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
+import PropTypes from "prop-types";
 
-import { Button } from './Button';
-import './header.css';
+import { Button } from "./Button";
+import "./header.css";
 
 export const Header = ({ user, onLogin, onLogout, onCreateAccount }) => (
   <header>
     <div className="storybook-header">
       <div>
-        <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+        <svg
+          width="32"
+          height="32"
+          viewBox="0 0 32 32"
+          xmlns="http://www.w3.org/2000/svg"
+        >
           <g fill="none" fillRule="evenodd">
             <path
               d="M10 0h12a10 10 0 0110 10v12a10 10 0 01-10 10H10A10 10 0 010 22V10A10 10 0 0110 0z"
@@ -37,7 +42,12 @@ export const Header = ({ user, onLogin, onLogout, onCreateAccount }) => (
         ) : (
           <>
             <Button size="small" onClick={onLogin} label="Log in" />
-            <Button primary size="small" onClick={onCreateAccount} label="Sign up" />
+            <Button
+              primary
+              size="small"
+              onClick={onCreateAccount}
+              label="Sign up"
+            />
           </>
         )}
       </div>

--- a/frontend/src/stories/Header.stories.js
+++ b/frontend/src/stories/Header.stories.js
@@ -1,14 +1,14 @@
-import { Header } from './Header';
-import { fn } from '@storybook/test';
+import { Header } from "./Header";
+import { fn } from "@storybook/test";
 
 export default {
-  title: 'Example/Header',
+  title: "Example/Header",
   component: Header,
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
-  tags: ['autodocs'],
+  tags: ["autodocs"],
   parameters: {
     // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
-    layout: 'fullscreen',
+    layout: "fullscreen",
   },
   args: {
     onLogin: fn(),
@@ -20,7 +20,7 @@ export default {
 export const LoggedIn = {
   args: {
     user: {
-      name: 'Jane Doe',
+      name: "Jane Doe",
     },
   },
 };

--- a/frontend/src/stories/Page.jsx
+++ b/frontend/src/stories/Page.jsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React from "react";
 
-import { Header } from './Header';
-import './page.css';
+import { Header } from "./Header";
+import "./page.css";
 
 export const Page = () => {
   const [user, setUser] = React.useState();
@@ -10,49 +10,67 @@ export const Page = () => {
     <article>
       <Header
         user={user}
-        onLogin={() => setUser({ name: 'Jane Doe' })}
+        onLogin={() => setUser({ name: "Jane Doe" })}
         onLogout={() => setUser(undefined)}
-        onCreateAccount={() => setUser({ name: 'Jane Doe' })}
+        onCreateAccount={() => setUser({ name: "Jane Doe" })}
       />
 
       <section className="storybook-page">
         <h2>Pages in Storybook</h2>
         <p>
-          We recommend building UIs with a{' '}
-          <a href="https://componentdriven.org" target="_blank" rel="noopener noreferrer">
+          We recommend building UIs with a{" "}
+          <a
+            href="https://componentdriven.org"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <strong>component-driven</strong>
-          </a>{' '}
+          </a>{" "}
           process starting with atomic components and ending with pages.
         </p>
         <p>
-          Render pages with mock data. This makes it easy to build and review page states without
-          needing to navigate to them in your app. Here are some handy patterns for managing page
-          data in Storybook:
+          Render pages with mock data. This makes it easy to build and review
+          page states without needing to navigate to them in your app. Here are
+          some handy patterns for managing page data in Storybook:
         </p>
         <ul>
           <li>
-            Use a higher-level connected component. Storybook helps you compose such data from the
-            "args" of child component stories
+            Use a higher-level connected component. Storybook helps you compose
+            such data from the "args" of child component stories
           </li>
           <li>
-            Assemble data in the page component from your services. You can mock these services out
-            using Storybook.
+            Assemble data in the page component from your services. You can mock
+            these services out using Storybook.
           </li>
         </ul>
         <p>
-          Get a guided tutorial on component-driven development at{' '}
-          <a href="https://storybook.js.org/tutorials/" target="_blank" rel="noopener noreferrer">
+          Get a guided tutorial on component-driven development at{" "}
+          <a
+            href="https://storybook.js.org/tutorials/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Storybook tutorials
           </a>
-          . Read more in the{' '}
-          <a href="https://storybook.js.org/docs" target="_blank" rel="noopener noreferrer">
+          . Read more in the{" "}
+          <a
+            href="https://storybook.js.org/docs"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             docs
           </a>
           .
         </p>
         <div className="tip-wrapper">
-          <span className="tip">Tip</span> Adjust the width of the canvas with the{' '}
-          <svg width="10" height="10" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+          <span className="tip">Tip</span> Adjust the width of the canvas with
+          the{" "}
+          <svg
+            width="10"
+            height="10"
+            viewBox="0 0 12 12"
+            xmlns="http://www.w3.org/2000/svg"
+          >
             <g fill="none" fillRule="evenodd">
               <path
                 d="M1.5 5.2h4.8c.3 0 .5.2.5.4v5.1c-.1.2-.3.3-.4.3H1.4a.5.5 0 01-.5-.4V5.7c0-.3.2-.5.5-.5zm0-2.1h6.9c.3 0 .5.2.5.4v7a.5.5 0 01-1 0V4H1.5a.5.5 0 010-1zm0-2.1h9c.3 0 .5.2.5.4v9.1a.5.5 0 01-1 0V2H1.5a.5.5 0 010-1zm4.3 5.2H2V10h3.8V6.2z"

--- a/frontend/src/stories/Page.stories.js
+++ b/frontend/src/stories/Page.stories.js
@@ -1,13 +1,13 @@
-import { within, userEvent, expect } from '@storybook/test';
+import { within, userEvent, expect } from "@storybook/test";
 
-import { Page } from './Page';
+import { Page } from "./Page";
 
 export default {
-  title: 'Example/Page',
+  title: "Example/Page",
   component: Page,
   parameters: {
     // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
-    layout: 'fullscreen',
+    layout: "fullscreen",
   },
 };
 
@@ -17,12 +17,12 @@ export const LoggedOut = {};
 export const LoggedIn = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const loginButton = canvas.getByRole('button', { name: /Log in/i });
+    const loginButton = canvas.getByRole("button", { name: /Log in/i });
     await expect(loginButton).toBeInTheDocument();
     await userEvent.click(loginButton);
     await expect(loginButton).not.toBeInTheDocument();
 
-    const logoutButton = canvas.getByRole('button', { name: /Log out/i });
+    const logoutButton = canvas.getByRole("button", { name: /Log out/i });
     await expect(logoutButton).toBeInTheDocument();
   },
 };

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -4,8 +4,9 @@ import Footer from "main/components/Nav/Footer";
 describe("Footer tests", () => {
   test("renders correctly", async () => {
     render(<Footer />);
-    const expectedText = "This is a sample webapp using React with a Spring Boot backend. See the source code on Github.";
-    expect(screen.getByTestId('Footer').textContent).toBe(expectedText);
+    const expectedText =
+      "This is a sample webapp using React with a Spring Boot backend. See the source code on Github.";
+    expect(screen.getByTestId("Footer").textContent).toBe(expectedText);
     // await screen.findByText(
     //   /This is a sample webapp using React with a Spring Boot backend./,
     // );
@@ -13,5 +14,4 @@ describe("Footer tests", () => {
     // const githubLink = screen.getByText("Github");
     // expect(githubLink).toBeInTheDocument();
   });
-
 });

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -4,8 +4,14 @@ import Footer from "main/components/Nav/Footer";
 describe("Footer tests", () => {
   test("renders correctly", async () => {
     render(<Footer />);
-    await screen.findByText(
-      /This is a sample webapp using React with a Spring Boot backend./,
-    );
+    const expectedText = "This is a sample webapp using React with a Spring Boot backend. See the source code on Github.";
+    expect(screen.getByTestId('Footer').textContent).toBe(expectedText);
+    // await screen.findByText(
+    //   /This is a sample webapp using React with a Spring Boot backend./,
+    // );
+    // await screen.findByText(/source code on/);
+    // const githubLink = screen.getByText("Github");
+    // expect(githubLink).toBeInTheDocument();
   });
+
 });


### PR DESCRIPTION
This PR adds the github actions workflows for the frontend, along with the template for the github pages site.

These workflows have been updated in some cases for later versions of the github actions scripts.